### PR TITLE
Allow macOS to recreate window when you click on the icon in the dock.

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,9 +6,13 @@ const path = require('path');
 const appMenu = require('./src/Menu');
 
 let mainWindow;
-let messagesURL = path.join('file://', __dirname, '/index.html')
-  , destroyWindow = () => { mainWindow = null; }
-  , closeAllWindow = () => { if (process.platform !== 'darwin') app.quit(); };
+let messagesURL = path.join('file://', __dirname, '/index.html'),
+  destroyWindow = () => {
+    mainWindow = null;
+  },
+  closeAllWindow = () => {
+    if (process.platform !== 'darwin') app.quit();
+  };
 
 let createWindow = () => {
   mainWindow = new BrowserWindow({
@@ -25,11 +29,12 @@ let createWindow = () => {
 
   mainWindow.loadURL(messagesURL);
   mainWindow.on('closed', destroyWindow);
-
 };
 
 app.on('ready', createWindow);
 app.on('activate', createWindow);
 app.on('window-all-closed', closeAllWindow);
 
-ipcMain.on('close', () => { app.quit(); });
+ipcMain.on('close', () => {
+  app.quit();
+});

--- a/main.js
+++ b/main.js
@@ -29,6 +29,7 @@ let createWindow = () => {
 };
 
 app.on('ready', createWindow);
+app.on('activate', createWindow);
 app.on('window-all-closed', closeAllWindow);
 
-ipcMain.on('close', () => { app.quit() });
+ipcMain.on('close', () => { app.quit(); });


### PR DESCRIPTION
Currently when you close the app on macOS, if you click the icon in the dock it doesn't reopen the app. The `activate` event will allow the window to be reopened if there is no mainWindow set. #1